### PR TITLE
Deleted max-width parameter from alternate-login tag

### DIFF
--- a/core/css/guest.css
+++ b/core/css/guest.css
@@ -159,7 +159,6 @@ form #datadirField legend {
 	margin: 30px 15px 20px;
 	display: block;
 	min-width: 260px;
-	max-width: 400px;
 	overflow: hidden;
 }
 


### PR DESCRIPTION
![nextcloud_fix_registrieren](https://user-images.githubusercontent.com/1073833/72680832-b3070380-3abe-11ea-9203-ec2b7ff961ca.PNG)
When using app "https://github.com/pellaeon/registration" the "Registration" button on the start page is off-center. This seems to result from the combination of min-width and max-width for the css-tag #alternate-login, defined here.